### PR TITLE
Correct version sorting

### DIFF
--- a/localshop/apps/packages/models.py
+++ b/localshop/apps/packages/models.py
@@ -4,6 +4,7 @@ import os
 from docutils.utils import SystemMessage
 from shutil import copyfileobj
 from tempfile import NamedTemporaryFile
+import pkg_resources  # from `distribute`
 
 from django.conf import settings
 from django.db import models
@@ -100,6 +101,12 @@ class Package(models.Model):
         return reverse('dashboard:package_detail', kwargs={
             'repo': self.repository.slug, 'name': self.name
         })
+
+    def get_ordered_releases(self):
+        releases = list(self.releases.all())
+        releases.sort(key=lambda rel: pkg_resources.parse_version(rel.version),
+                      reverse=True)
+        return releases
 
     def get_all_releases(self):
         result = {}

--- a/localshop/templates/dashboard/package_detail.html
+++ b/localshop/templates/dashboard/package_detail.html
@@ -95,7 +95,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {% for release in package.releases.all %}
+                            {% for release in package.get_ordered_releases %}
                             <tr>
                                 <th colspan="8">{{ release.version }}</th>
                             </tr>

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'sqlparse==0.1.15',
         'whitenoise==1.0.6',
         'Versio==0.2.1',
+        'distribute',
     ],
     tests_require=tests_require,
     extras_require={'test': tests_require},


### PR DESCRIPTION
(untested, at the moment)

Correctly sorts versions like "1.1.0", "1.2.0", ... "1.10.0", "1.11.0".

(using the same sorting as pip does)
