### PR TITLE
Increase ReleaseFile python_version field's max length

### DIFF
--- a/src/localshop/apps/packages/migrations/0012_releasefile_python_version_max_length.py
+++ b/src/localshop/apps/packages/migrations/0012_releasefile_python_version_max_length.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('packages', '0011_package_name'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='releasefile',
+            name='python_version',
+            field=models.CharField(max_length=100),
+            preserve_default=True,
+        ),
+    ]

--- a/src/localshop/apps/packages/models.py
+++ b/src/localshop/apps/packages/models.py
@@ -246,7 +246,7 @@ class ReleaseFile(models.Model):
         null=True,
     )
     md5_digest = models.CharField(max_length=512)
-    python_version = models.CharField(max_length=50)
+    python_version = models.CharField(max_length=100)
     requires_python = models.CharField(
         max_length=255,
         blank=True,

--- a/src/localshop/apps/packages/urls.py
+++ b/src/localshop/apps/packages/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
     url(r'^(?P<repo>[-\._\w]+)/?$', views.SimpleIndex.as_view(),
         name='simple_index'),
 
-    url(r'^(?P<repo>[-\._\w]+)/(?P<slug>[-\._\w\s]+)/$',
+    url(r'^(?P<repo>[-\._\w]+)/(?P<slug>[-\._\w\s]+)/?$',
         cache_page(60)(views.SimpleDetail.as_view()),
         name='simple_detail'),
 

--- a/tests/apps/packages/views/test_simple_detail.py
+++ b/tests/apps/packages/views/test_simple_detail.py
@@ -43,7 +43,7 @@ def test_success_redirect_to_normalized_name(django_app, admin_user, repository,
         }), user=admin_user)
 
     assert response.status_code == 302
-    assert response.headers['Location'] == '/repo/%s/%s/' % (
+    assert response.headers['Location'] == '/repo/%s/%s' % (
         repository.slug, release_file.release.package.normalized_name)
 
 
@@ -100,4 +100,4 @@ def test_wrong_package_name_case(django_app, admin_user, repository, pypi_stub):
         }), user=admin_user)
 
     assert response.status_code == 302
-    assert response.url == '/repo/default/minibar/'
+    assert response.url == '/repo/default/minibar'


### PR DESCRIPTION
Data example ([SoundFile](https://pypi.org/project/SoundFile/) package):
```python
...
'python_version': 'py2.py3.cp26.cp27.cp32.cp33.cp34.cp35.cp36.pp27.pp32.pp33',
...
```

```ipython
In [48]: len('py2.py3.cp26.cp27.cp32.cp33.cp34.cp35.cp36.pp27.pp32.pp33')
Out[48]: 57
```

**Misc:** fix 404 without trailing slash for `/repo/<repo_name>/<package_name>`
